### PR TITLE
PR REL EASE INSTALL

### DIFF
--- a/.github/workflows/old-test.yml
+++ b/.github/workflows/old-test.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node dependencies
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2.1.5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/old-test.yml
+++ b/.github/workflows/old-test.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node dependencies
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2.1.5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
+      fail-fast: false
 
     steps:
       - name: Checkout project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -980,6 +980,21 @@ In `package.json`, use the "standard" property:
 
 [view diff](https://github.com/standard/standard/compare/v4.5.4...v5.0.0)
 
+eslint v1.0.0 is released! eslint added some new rules that are nice, and lots of existing rules have subtle behavior changes designed to catch more errors.
+
+Let's talk about the next version of standard! We bumped the major version to v5.0.0 to pull in these improvements.
+
+#### New rules:
+- space before/after arrow functions (https://github.com/feross/eslint-config-standard/commit/cf31561306f102b0772de55cd410b20912e733ee)
+- indent switch "case" sections (https://github.com/feross/eslint-config-standard/commit/c6b10f68aa31e323933b14e04b50d8c1075ef28c)
+- don't reassign class variable names (https://github.com/feross/eslint-config-standard/commit/96c727fdf917f213e23320cc9971a0e2e5bf2b7b)
+- don't reassign const variables (https://github.com/feross/eslint-config-standard/commit/2dd1a09edcff6656731a394231e93850e55cc39d)
+- don't use .call() or .apply() to invoke a function unless it's necessary (https://github.com/feross/eslint-config-standard/commit/6fba6e34d9281a716bf7ffc9fc5d804f6403f505)
+
+#### Changed rules:
+- use `no-extra-parens` instead of the deprecated `no-wrap-func` rule (https://github.com/feross/eslint-config-standard/commit/fc8a076c156d949b0b6046281f2e5f5c91e7da62)
+- `indent` got stricter and catches errors in object literal indentation. 12/131 repos in the test suite started failing after this rule was improved.
+
 ## [4.5.4] - 2015-07-13
 
 [view diff](https://github.com/standard/standard/compare/v4.5.3...v4.5.4)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <p align="center">
   <a href="https://discord.gg/ZegqCBr"><img src="https://img.shields.io/discord/612704110008991783" alt="discord"></a>
-  <a href="https://github.com/standard/standard/workflows/Test/badge.svg"><img src="https://github.com/standard/standard/workflows/Test/badge.svg" alt="status badge Node tests"></a>
-  <a href="https://github.com/standard/standard/workflows/Old%20test/badge.svg"><img src="https://github.com/standard/standard/workflows/Old%20test/badge.svg" alt="status badge old Node test"></a>
+  <a href="https://github.com/standard/standard/actions?query=workflow%3ATest"><img src="https://github.com/standard/standard/workflows/Test/badge.svg" alt="status badge Node tests"></a>
+  <a href="https://github.com/standard/standard/actions?query=workflow%3A%22Old+test%22"><img src="https://github.com/standard/standard/workflows/Old%20test/badge.svg" alt="status badge old Node test"></a>
   <a href="https://www.npmjs.com/package/standard"><img src="https://img.shields.io/npm/v/standard.svg" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/eslint-config-standard"><img src="https://img.shields.io/npm/dm/eslint-config-standard.svg" alt="npm downloads"></a>
   <a href="https://standardjs.com"><img src="https://img.shields.io/badge/code_style-standard-brightgreen.svg" alt="Standard - JavaScript Style Guide"></a>

--- a/README.md
+++ b/README.md
@@ -484,13 +484,13 @@ complexity is worth it.
 To use a custom parser, first install it from npm:
 
 ```bash
-npm install babel-eslint --save-dev
+npm install @babel/eslint-parser --save-dev
 ```
 
 Then run:
 
 ```bash
-$ standard --parser babel-eslint
+$ standard --parser @babel/eslint-parser
 ```
 
 Or, add this to `package.json`:
@@ -498,7 +498,7 @@ Or, add this to `package.json`:
 ```json
 {
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
@@ -550,17 +550,17 @@ to layer your changes on top.
 
 ### Flow
 
-To use Flow, you need to run `standard` with `babel-eslint` as the parser and
+To use Flow, you need to run `standard` with `@babel/eslint-parser` as the parser and
 `eslint-plugin-flowtype` as a plugin.
 
 ```bash
-npm install babel-eslint eslint-plugin-flowtype --save-dev
+npm install @babel/eslint-parser eslint-plugin-flowtype --save-dev
 ```
 
 Then run:
 
 ```bash
-$ standard --parser babel-eslint --plugin flowtype
+$ standard --parser @babel/eslint-parser --plugin flowtype
 ```
 
 Or, add this to `package.json`:
@@ -568,7 +568,7 @@ Or, add this to `package.json`:
 ```json
 {
   "standard": {
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "plugins": [ "flowtype" ]
   }
 }
@@ -760,7 +760,7 @@ Lint the provided source `text`. An `opts` object may be provided:
   globals: [],  // custom global variables to declare
   plugins: [],  // custom eslint plugins
   envs: [],     // custom eslint environment
-  parser: ''    // custom js parser (e.g. babel-eslint)
+  parser: ''    // custom js parser (e.g. @babel/eslint-parser)
 }
 ```
 
@@ -806,7 +806,7 @@ var opts = {
   globals: [],  // global variables to declare
   plugins: [],  // eslint plugins
   envs: [],     // eslint environment
-  parser: ''    // js parser (e.g. babel-eslint)
+  parser: ''    // js parser (e.g. @babel/eslint-parser)
 }
 ```
 

--- a/docs/README-esla.md
+++ b/docs/README-esla.md
@@ -315,7 +315,7 @@ Busque el registro de extension para **["Standard Code Style"][brackets-1]**.
 
 WebStorm [recientemente anuncio soporte nativo](https://blog.jetbrains.com/webstorm/2017/01/webstorm-2017-1-eap-171-2272/) para `standard` directamente en el IDE.
 
-Si aun prefieres configurar `standard` manualmente [sigue esta guía](webstorm-2). Esto se aplica a todos los productos de JetBrains, incluyendo PhpStorm, IntelliJ, RubyMine y etc.
+Si aun prefieres configurar `standard` manualmente [sigue esta guía][webstorm-2]. Esto se aplica a todos los productos de JetBrains, incluyendo PhpStorm, IntelliJ, RubyMine y etc.
 
 [webstorm-1]: https://www.jetbrains.com/webstorm/
 [webstorm-2]: webstorm.md

--- a/docs/README-esla.md
+++ b/docs/README-esla.md
@@ -459,10 +459,10 @@ de las propuestas que estan en "Stage 4" del proceso de propuestas.
 
 Para soportar características experimentales del lenguaje, `standard` soporta especificar un parser JS customizado. Antes de que uses un parser customizado, considera si la complejidad agregada vale la pena.
 
-Para usar un parser customizado, instálalo desde npm (ejemplo: `npm install babel-eslint`) y ejecuta esto:
+Para usar un parser customizado, instálalo desde npm (ejemplo: `npm install @babel/eslint-parser`) y ejecuta esto:
 
 ```bash
-$ standard --parser babel-eslint
+$ standard --parser @babel/eslint-parser
 ```
 
 O, agrega esto a `package.json`:
@@ -470,12 +470,12 @@ O, agrega esto a `package.json`:
 ```json
 {
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
 
-Si `standard` está instalado globalmente (ej: `npm install standard --global`), entonces asegúrate de instalar `babel-eslint` globalmente también com `npm install babel-eslint --global`.
+Si `standard` está instalado globalmente (ej: `npm install standard --global`), entonces asegúrate de instalar `@babel/eslint-parser` globalmente también com `npm install @babel/eslint-parser --global`.
 
 ## ¿Puedo usar una variación de lenguaje JavaScript, como Flow?
 
@@ -494,7 +494,7 @@ O, agrega esto a `package.json`:
 ```json
 {
   "standard": {
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "plugins": [
       "flowtype"
     ]
@@ -623,7 +623,7 @@ var opts = {
   globals: [],  // global variables to declare
   plugins: [],  // eslint plugins
   envs: [],     // eslint environment
-  parser: ''    // js parser (e.g. babel-eslint)
+  parser: ''    // js parser (e.g. @babel/eslint-parser)
 }
 ```
 
@@ -659,7 +659,7 @@ var opts = {
   globals: [],  // global variables to declare
   plugins: [],  // eslint plugins
   envs: [],     // eslint environment
-  parser: ''    // js parser (e.g. babel-eslint)
+  parser: ''    // js parser (e.g. @babel/eslint-parser)
 }
 ```
 

--- a/docs/README-fr.md
+++ b/docs/README-fr.md
@@ -324,7 +324,7 @@ pour `standard` directement dans l'IDE.
 
 Si vous préférez toujours configurer `standard` manuellement, [suivez ce guide][webstorm-1]. Cela s'applique à tous les produits JetBrains, inclus PhpStorm, IntelliJ, RubyMine, etc.
 
-[webstorm-1]: docs/webstorm.md
+[webstorm-1]: webstorm.md
 
 ## Il y a-t-il un badge readme?
 

--- a/docs/README-fr.md
+++ b/docs/README-fr.md
@@ -467,13 +467,13 @@ Pour supporter les fonctionalités expérimentales, `standard` supporte la spéc
 Pour utiliser un autre parseur, installez-le d'abord avec npm:
 
 ```bash
-npm install babel-eslint --save-dev
+npm install @babel/eslint-parser --save-dev
 ```
 
 Ensuite éxécutez:
 
 ```bash
-$ standard --parser babel-eslint
+$ standard --parser @babel/eslint-parser
 ```
 
 Ou, ajoutez ça au `package.json`:
@@ -481,13 +481,13 @@ Ou, ajoutez ça au `package.json`:
 ```json
 {
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
 
-Si `standard` est installé globalement (`npm install standard --global`), soyez surs d'installer `babel-eslint` globalement aussi, avec
-`npm install babel-eslint --global`.
+Si `standard` est installé globalement (`npm install standard --global`), soyez surs d'installer `@babel/eslint-parser` globalement aussi, avec
+`npm install @babel/eslint-parser --global`.
 
 ## Puis-je utiliser une variation du langage JavaScript, comme Flow ou TypeScript?
 
@@ -497,17 +497,17 @@ Pour supporter les variations, `standard` supporte la spécification d'un parseu
 
 ### Flow
 
-Pour utiliser Flow, vous allez devoir éxécuter `standard` avec `babel-eslint` comme parseur et
+Pour utiliser Flow, vous allez devoir éxécuter `standard` avec `@babel/eslint-parser` comme parseur et
 `eslint-plugin-flowtype` comme plugin.
 
 ```bash
-npm install babel-eslint eslint-plugin-flowtype --save-dev
+npm install @babel/eslint-parser eslint-plugin-flowtype --save-dev
 ```
 
 Ensuite éxécutez:
 
 ```bash
-$ standard --parser babel-eslint --plugin flowtype
+$ standard --parser @babel/eslint-parser --plugin flowtype
 ```
 
 Ou, ajoutez ça au `package.json`:
@@ -515,7 +515,7 @@ Ou, ajoutez ça au `package.json`:
 ```json
 {
   "standard": {
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "plugins": [ "flowtype" ]
   }
 }
@@ -523,8 +523,8 @@ Ou, ajoutez ça au `package.json`:
 
 *Note: `plugin` et `plugins` sont équivalents.*
 
-Si `standard` est installé globalement (`npm install standard --global`), soyez sur d'installer `babel-eslint` et `eslint-plugin-flowtype` globalement aussi, avec
-`npm install babel-eslint eslint-plugin-flowtype --global`.
+Si `standard` est installé globalement (`npm install standard --global`), soyez sur d'installer `@babel/eslint-parser` et `eslint-plugin-flowtype` globalement aussi, avec
+`npm install @babel/eslint-parser eslint-plugin-flowtype --global`.
 
 ### TypeScript
 
@@ -681,7 +681,7 @@ Lint le texte fourni. Un objet `opts` peut être fourni:
   globals: [],  // custom global variables to declare
   plugins: [],  // custom eslint plugins
   envs: [],     // custom eslint environment
-  parser: ''    // custom js parser (e.g. babel-eslint)
+  parser: ''    // custom js parser (e.g. @babel/eslint-parser)
 }
 ```
 
@@ -725,7 +725,7 @@ var opts = {
   globals: [],  // global variables to declare
   plugins: [],  // eslint plugins
   envs: [],     // eslint environment
-  parser: ''    // js parser (e.g. babel-eslint)
+  parser: ''    // js parser (e.g. @babel/eslint-parser)
 }
 ```
 

--- a/docs/README-fr.md
+++ b/docs/README-fr.md
@@ -87,7 +87,7 @@ _Note: Pour executer les commandes précédentes, [Node.js](http://nodejs.org) e
 
 ## Utilisation
 
-Apres avoir installé `standard`, vous devriez pouvoir l'utiliser. Le cas le plus facile serait de verifier le style de tous les fichiers JavaScrtipt dans le dossier actuellement utilisé:
+Apres avoir installé `standard`, vous devriez pouvoir l'utiliser. Le cas le plus facile serait de verifier le style de tous les fichiers JavaScript dans le dossier actuellement utilisé:
 
 ```bash
 $ standard

--- a/docs/README-id.md
+++ b/docs/README-id.md
@@ -284,7 +284,7 @@ untuk `standard` langsung didalam IDE.
 
 Jika kamu lebih suka untuk mengkonfigurasi `standard` secara manual, [ikuti arahan disini][webstorm-1]. Arahan tersebuh dapat diaplikasikan kedalam seluruh produk JetBrains, termasuk PhpStorm, IntelliJ, RubyMine, etc.
 
-[webstorm-1]: docs/webstorm.md
+[webstorm-1]: webstorm.md
 
 ## Apakah terdapat badge readme?
 

--- a/docs/README-id.md
+++ b/docs/README-id.md
@@ -426,13 +426,13 @@ Untuk mendukun fitur bahasa eksperimental, `standard` menspesifikasikan dukungan
 Untuk mendukung parser kustom, pertama pasang dahulu dari npm:
 
 ```bash
-npm install babel-eslint --save-dev
+npm install @babel/eslint-parser --save-dev
 ```
 
 Lalu jalankan:
 
 ```bash
-$ standard --parser babel-eslint
+$ standard --parser @babel/eslint-parser
 ```
 
 Atau, tambahkan ini kedalam `package.json`:
@@ -440,7 +440,7 @@ Atau, tambahkan ini kedalam `package.json`:
 ```json
 {
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
@@ -453,16 +453,16 @@ Untuk mendukung varian bahasa dari Javascript, `standard` mendukung menspesifika
 
 ### Flow
 
-Untuk menggunakan Flow, kamu harus menjalankan `standard` dengan `babel-eslint` sebagai parsernya dan `eslint-plugin-flowtype` sebagai pluginnya.
+Untuk menggunakan Flow, kamu harus menjalankan `standard` dengan `@babel/eslint-parser` sebagai parsernya dan `eslint-plugin-flowtype` sebagai pluginnya.
 
 ```bash
-npm install babel-eslint eslint-plugin-flowtype --save-dev
+npm install @babel/eslint-parser eslint-plugin-flowtype --save-dev
 ```
 
 Lalu jalankan:
 
 ```bash
-$ standard --parser babel-eslint --plugin flowtype
+$ standard --parser @babel/eslint-parser --plugin flowtype
 ```
 
 Atau, tambahkan ini kedalam `package.json`:
@@ -470,7 +470,7 @@ Atau, tambahkan ini kedalam `package.json`:
 ```json
 {
   "standard": {
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "plugins": [ "flowtype" ]
   }
 }
@@ -645,7 +645,7 @@ Lint sumber `text` yang disediakan. Objek `opts` bisa juga disediakan:
   globals: [],  // variabel global kustom untuk dideklarasikan
   plugins: [],  // plugin eslint kustom
   envs: [],     // environment kustom eslint
-  parser: ''    // parser js kustom (e.g. babel-eslint)
+  parser: ''    // parser js kustom (e.g. @babel/eslint-parser)
 }
 ```
 Option tambahan mungkin di ambil dari `package.json` jika ditemukan didalam direktori yang sedang digunakan.
@@ -688,7 +688,7 @@ var opts = {
   globals: [],  // variabel global untuk dideklarasikan
   plugins: [],  // plugin eslint
   envs: [],     // environment eslint
-  parser: ''    // parser js (e.g. babel-eslint)
+  parser: ''    // parser js (e.g. @babel/eslint-parser)
 }
 ```
 

--- a/docs/README-iteu.md
+++ b/docs/README-iteu.md
@@ -314,7 +314,7 @@ Se preferisci configurare `standard` manualmente, [segui questa guida][webstorm-
 
 If you still prefer to configure `standard` manually, [follow this guide][webstorm-1]. This applies to all JetBrains products, including PhpStorm, IntelliJ, RubyMine, etc.
 
-[webstorm-1]: docs/webstorm.md
+[webstorm-1]: webstorm.md
 
 ## Esiste un banner?
 

--- a/docs/README-iteu.md
+++ b/docs/README-iteu.md
@@ -312,8 +312,6 @@ per `standard` direttamente nell'IDE.
 
 Se preferisci configurare `standard` manualmente, [segui questa guida][webstorm-1]. Questa guida va bene per tutti i prodotti JetBrains, come ad esempio PhpStorm, IntelliJ, RubyMine, ecc.
 
-If you still prefer to configure `standard` manually, [follow this guide][webstorm-1]. This applies to all JetBrains products, including PhpStorm, IntelliJ, RubyMine, etc.
-
 [webstorm-1]: webstorm.md
 
 ## Esiste un banner?

--- a/docs/README-iteu.md
+++ b/docs/README-iteu.md
@@ -445,10 +445,10 @@ Oppure aggiungi questo al tuo `package.json`:
 
 Per supportare funzionalità sperimentali, `standard` permette di configurare uno perser JavaScript su misura (custom). Prima di aggiungere un diverso parser, considera se la complessità che si andrà ad aggiungere ne valga la pena.
 
-Per usare un parser su misura (custom), installalo da npm (esempio: `npm install --save-dev babel-eslint`) ed esegui:
+Per usare un parser su misura (custom), installalo da npm (esempio: `npm install --save-dev @babel/eslint-parser`) ed esegui:
 
 ```bash
-$ standard --parser babel-eslint
+$ standard --parser @babel/eslint-parser
 ```
 
 Oppure aggiungi questo al tuo `package.json`:
@@ -456,13 +456,13 @@ Oppure aggiungi questo al tuo `package.json`:
 ```json
 {
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
 
-Se `standard` è installato globalmente (i.e. `npm install standard --global`), allora assicurati che anche `babel-eslint` sia installato globalmente, con
-`npm install babel-eslint --global`.
+Se `standard` è installato globalmente (i.e. `npm install standard --global`), allora assicurati che anche `@babel/eslint-parser` sia installato globalmente, con
+`npm install @babel/eslint-parser --global`.
 
 ## Posso usare varianti di JavaScript come Flow?
 
@@ -484,10 +484,10 @@ Oppure aggiungi questo al tuo `package.json`:
 }
 ```
 
-Per usare Flow, hai bisogno di usare `babel-eslint` come parser, Quindi, esegui `npm install eslint-plugin-flowtype babel-eslint` e dopo di che esegui:
+Per usare Flow, hai bisogno di usare `@babel/eslint-parser` come parser, Quindi, esegui `npm install eslint-plugin-flowtype @babel/eslint-parser` e dopo di che esegui:
 
 ```bash
-$ standard --plugin flowtype --parser babel-eslint
+$ standard --plugin flowtype --parser @babel/eslint-parser
 ```
 
 Oppure aggiungi questo al tuo `package.json`:
@@ -496,7 +496,7 @@ Oppure aggiungi questo al tuo `package.json`:
 {
   "standard": {
     "plugins": [ "flowtype" ],
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
@@ -623,7 +623,7 @@ Esegue il lint sul parametro passato come input `text`. Il parametro `opts` è u
   globals: [],  // particolari variabili globali da dichiarare
   plugins: [],  // particolari plugin eslint
   envs: [],     // particolari eslint environments
-  parser: ''    // particolari parser JavaScript (es. babel-eslint)
+  parser: ''    // particolari parser JavaScript (es. @babel/eslint-parser)
 }
 ```
 
@@ -667,7 +667,7 @@ var opts = {
   globals: [],  // particolari variabili globali da dichiarare
   plugins: [],  // particolari plugin eslint
   envs: [],     // particolari eslint environments
-  parser: ''    // particolari parser JavaScript (es. babel-eslint)
+  parser: ''    // particolari parser JavaScript (es. @babel/eslint-parser)
 }
 ```
 

--- a/docs/README-ja.md
+++ b/docs/README-ja.md
@@ -423,13 +423,13 @@ $ standard --global myVar1 --global myVar2
 カスタムパーサーを使用するには、まずnpmから以下をインストールしてください。：
 
 ```bash
-npm install babel-eslint --save-dev
+npm install @babel/eslint-parser --save-dev
 ```
 
 そして、次のコマンドを実行します。：
 
 ```bash
-$ standard --parser babel-eslint
+$ standard --parser @babel/eslint-parser
 ```
 
 あるいは、次の内容を`package.json`に追加してください。：
@@ -437,7 +437,7 @@ $ standard --parser babel-eslint
 ```json
 {
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
@@ -450,16 +450,16 @@ JavaScriptの代替言語をサポートするため、`standard`は変更され
 
 ### Flow
 
-Flowを使用するには、`babel-eslint`をパーサとして、`eslint-plugin-flowtype`をプラグインとして`standard`を実行する必要があります。
+Flowを使用するには、`@babel/eslint-parser`をパーサとして、`eslint-plugin-flowtype`をプラグインとして`standard`を実行する必要があります。
 
 ```bash
-npm install babel-eslint eslint-plugin-flowtype --save-dev
+npm install @babel/eslint-parser eslint-plugin-flowtype --save-dev
 ```
 
 そして、次のコマンドを実行します。：
 
 ```bash
-$ standard --parser babel-eslint --plugin flowtype
+$ standard --parser @babel/eslint-parser --plugin flowtype
 ```
 
 あるいは、次の内容を`package.json`に追加してください。：
@@ -467,7 +467,7 @@ $ standard --parser babel-eslint --plugin flowtype
 ```json
 {
   "standard": {
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "plugins": [ "flowtype" ]
   }
 }
@@ -648,7 +648,7 @@ $ standard --verbose | snazzy
   globals: [],  // custom global variables to declare
   plugins: [],  // custom eslint plugins
   envs: [],     // custom eslint environment
-  parser: ''    // custom js parser (e.g. babel-eslint)
+  parser: ''    // custom js parser (e.g. @babel/eslint-parser)
 }
 ```
 
@@ -692,7 +692,7 @@ var opts = {
   globals: [],  // global variables to declare
   plugins: [],  // eslint plugins
   envs: [],     // eslint environment
-  parser: ''    // js parser (e.g. babel-eslint)
+  parser: ''    // js parser (e.g. @babel/eslint-parser)
 }
 ```
 

--- a/docs/README-ja.md
+++ b/docs/README-ja.md
@@ -282,7 +282,7 @@ WebStormでは、IDEで`standard`が[ネイティブサポートされるよう�
 
 `standard`を手動で設定したい場合、[こちらのガイド][webstorm-1]に従ってください。これは、PhpStorm、IntelliJ、RubyMineなど、すべてのJetBrains製品に適用されます。
 
-[webstorm-1]: docs/webstorm.md
+[webstorm-1]: webstorm.md
 
 <h2 id="is-there-a-readme-badge">readme用のバッジはありますか？</h2>
 

--- a/docs/README-kokr.md
+++ b/docs/README-kokr.md
@@ -300,9 +300,9 @@ extension registry에서 **["Standard Code Style"][brackets-1]** 을 검색하�
 
 WebStrom은 `standard`가 직접적으로 IDE에서 사용가능다고 [기본적인 지원에 관한 최근 발표](https://blog.jetbrains.com/webstorm/2017/01/webstorm-2017-1-eap-171-2272/) 했습니다.
 
-만약 수동으로 `standard`를 구성하려면 [안내서]([webstorm-1])를 따르십시오. 이것은 PhpStorm, IntelliJ, RubyMine 등 모든 JetBrains 제품에 적용됩니다.
+만약 수동으로 `standard`를 구성하려면 [안내서][webstorm-1]를 따르십시오. 이것은 PhpStorm, IntelliJ, RubyMine 등 모든 JetBrains 제품에 적용됩니다.
 
-[webstorm-1]: docs/webstorm.md
+[webstorm-1]: webstorm.md
 
 ## readme에 넣을 수 있는 뱃지로고가 있나요?
 

--- a/docs/README-kokr.md
+++ b/docs/README-kokr.md
@@ -441,13 +441,13 @@ $ standard --global myVar1 --global myVar2
 커스텀파서를 사용하기 전에 먼저 npm모듈을 설치합니다.
 
 ```bash
-npm install babel-eslint --save-dev
+npm install @babel/eslint-parser --save-dev
 ```
 
 다음을 수행합니다.
 
 ```bash
-$ standard --parser babel-eslint
+$ standard --parser @babel/eslint-parser
 ```
 
 혹은, `package.json`에 아래코드를 추가하세요.
@@ -455,12 +455,12 @@ $ standard --parser babel-eslint
 ```json
 {
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
 
-`standard'가 전역으로 설치되면 (즉,`npm install standard --global`), `babel-eslint`를 `npm install babel-eslint --global`과 함께 설치하십시오.
+`standard'가 전역으로 설치되면 (즉,`npm install standard --global`), `@babel/eslint-parser`를 `npm install @babel/eslint-parser --global`과 함께 설치하십시오.
 
 ## JavaScript와 다른 Flow 또는 TypeScript에서도 사용할 수 있나요?
 
@@ -470,16 +470,16 @@ JavaScript 언어 변형을 지원하기 위해 `standard`는 변경된 구문�
 
 ### Flow
 
-Flow를 사용하려면`babel-eslint`를 파서로 사용하고`eslint-plugin-flowtype`을 플러그인으로 사용하여`standard`를 실행해야합니다.
+Flow를 사용하려면`@babel/eslint-parser`를 파서로 사용하고`eslint-plugin-flowtype`을 플러그인으로 사용하여`standard`를 실행해야합니다.
 
 ```bash
-npm install babel-eslint eslint-plugin-flowtype --save-dev
+npm install @babel/eslint-parser eslint-plugin-flowtype --save-dev
 ```
 
 다음을 실행하세요.
 
 ```bash
-$ standard --parser babel-eslint --plugin flowtype
+$ standard --parser @babel/eslint-parser --plugin flowtype
 ```
 
 아니면, `package.json`에 아래 코드를 추가하세요.
@@ -487,7 +487,7 @@ $ standard --parser babel-eslint --plugin flowtype
 ```json
 {
   "standard": {
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "plugins": [ "flowtype" ]
   }
 }
@@ -495,7 +495,7 @@ $ standard --parser babel-eslint --plugin flowtype
 
 *주의 :`plugin`과 `plugins`는 동일합니다.*
 
-만약`standard`가 전역 적으로 설치된다면 (즉,`npm install standard - global`), `babel-eslint`와`eslint-plugin-flowtype`도 함께 설치해야 합니다. `npm install babel-eslint eslint-plugin-flowtype --global`.
+만약`standard`가 전역 적으로 설치된다면 (즉,`npm install standard - global`), `@babel/eslint-parser`와`eslint-plugin-flowtype`도 함께 설치해야 합니다. `npm install @babel/eslint-parser eslint-plugin-flowtype --global`.
 
 ### TypeScript
 
@@ -646,7 +646,7 @@ $ standard --verbose | snazzy
   globals: [],  // 선언할 커스텀 글로벌 변수
   plugins: [],  // 커스텀 eslint 플러그인
   envs: [],     // 커스텀 eslint 환경
-  parser: ''    // 커스텀 js 파서  (예: babel-eslint)
+  parser: ''    // 커스텀 js 파서  (예: @babel/eslint-parser)
 }
 ```
 
@@ -690,7 +690,7 @@ var opts = {
   globals: [],  // 선언할 글로벌 변수
   plugins: [],  // eslint 플러그인
   envs: [],     // eslint 환경
-  parser: ''    // js 파서 (예: babel-eslint)
+  parser: ''    // js 파서 (예: @babel/eslint-parser)
 }
 ```
 

--- a/docs/README-ptbr.md
+++ b/docs/README-ptbr.md
@@ -259,7 +259,7 @@ Para snippets de React, instale  **[vscode-react-standard][vscode-2]**.
 Ambos PhpStorm e WebStorm podem ser  [configurados para Standard Style][webstorm-2].
 
 [webstorm-1]: https://www.jetbrains.com/webstorm/
-[webstorm-2]: https://github.com/standard/standard/blob/master/docs/webstorm.md
+[webstorm-2]: webstorm.md
 
 ## FAQ
 

--- a/docs/README-ptbr.md
+++ b/docs/README-ptbr.md
@@ -381,17 +381,17 @@ Se você possui centenas de arquivos, adicionar comentários em cada um pode fic
 Antes de usar um custom parser, considere se a complexidade a mais no seu código faz com que o processo valha a pena.
 
 `standard` suporta custom JS parsers. Para usar um custom parser, instale via npm
-(por exemplo: `npm install babel-eslint`) e adicione isso ao seu `package.json`:
+(por exemplo: `npm install @babel/eslint-parser`) e adicione isso ao seu `package.json`:
 
 ```json
 {
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
 
-Se você está usando  `standard` de forma global (instalou com `-g`), você vai precisar instalar  `babel-eslint` globalmente como `npm install babel-eslint -g`.
+Se você está usando  `standard` de forma global (instalou com `-g`), você vai precisar instalar  `@babel/eslint-parser` globalmente como `npm install @babel/eslint-parser -g`.
 
 ### Posso usar uma linguagem variante de JavaScript, tipo Flow?
 
@@ -402,7 +402,7 @@ Antes de usar uma variante de JS customizada, considere se a complexidade a mais
 ```json
 {
   "standard": {
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "plugins": [
       "flowtype"
     ]
@@ -506,7 +506,7 @@ var opts = {
   globals: [],  // declaração de variáveis globais
   plugins: [],  // plugins eslint
   envs: [],     // ambiente eslint
-  parser: ''    // js parser (e.g. babel-eslint)
+  parser: ''    // js parser (e.g. @babel/eslint-parser)
 }
 ```
 
@@ -541,7 +541,7 @@ var opts = {
   globals: [],  // variáveis globais para declarar
   plugins: [],  // plugins eslint
   envs: [],     // ambiente eslint
-  parser: ''    // js parser (e.g. babel-eslint)
+  parser: ''    // js parser (e.g. @babel/eslint-parser)
 }
 ```
 

--- a/docs/README-zhcn.md
+++ b/docs/README-zhcn.md
@@ -427,10 +427,10 @@ $ standard --global myVar1 --global myVar2
 
 为了支持实验性的特性，`standard` 支持自定义 JavaScript 解析器。添加自定义解析器前请思考一下必要性。
 
-从 npm 安装并使用自定义的解析器（示例：`npm install babel-eslint`）：
+从 npm 安装并使用自定义的解析器（示例：`npm install @babel/eslint-parser`）：
 
 ```bash
-$ standard --parser babel-eslint
+$ standard --parser @babel/eslint-parser
 ```
 
 或者将其添加到  `package.json` 配置中：
@@ -438,12 +438,12 @@ $ standard --parser babel-eslint
 ```json
 {
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
 
-如果全局安装（`npm install standard --global`）了 `standard` 的话，那么请确保 `babel-eslint` 也用 `npm install babel-eslint --global` 全局安装。
+如果全局安装（`npm install standard --global`）了 `standard` 的话，那么请确保 `@babel/eslint-parser` 也用 `npm install @babel/eslint-parser --global` 全局安装。
 
 ## 我能使用其他 JavaScript 变种吗，例如 Flow？
 
@@ -587,7 +587,7 @@ $ standard --verbose | snazzy
   globals: [],  // 声明需要跳过检测的定义全局变量
   plugins: [],  // 自定义的 eslint 插件列表
   envs: [],     // 自定义的 eslint 环境
-  parser: ''    // 自定义的 js 解析器（例如 babel-eslint）
+  parser: ''    // 自定义的 js 解析器（例如 @babel/eslint-parser）
 }
 ```
 
@@ -631,7 +631,7 @@ var opts = {
   globals: [],  // 声明需要跳过检测的定义全局变量
   plugins: [],  // eslint 插件列表
   envs: [],     // eslint 环境
-  parser: ''    // js 解析器（例如 babel-eslint）
+  parser: ''    // js 解析器（例如 @babel/eslint-parser）
 }
 ```
 

--- a/docs/README-zhtw.md
+++ b/docs/README-zhtw.md
@@ -427,10 +427,10 @@ $ standard --global myVar1 --global myVar2
 
 為了支援實驗性質的語法，`standard` 支援客製化 JavaScript 語法解析器。在使用客製化語法解析器前，請考慮清楚是否值得去增加這些複雜度。
 
-要使用客製化語法解析器，可以從 npm 安裝（比如說：`npm install babel-eslint`），然後執行：
+要使用客製化語法解析器，可以從 npm 安裝（比如說：`npm install @babel/eslint-parser`），然後執行：
 
 ```bash
-$ standard --parser babel-eslint
+$ standard --parser @babel/eslint-parser
 ```
 
 或在 `package.json` 中加入：
@@ -438,12 +438,12 @@ $ standard --parser babel-eslint
 ```json
 {
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "@babel/eslint-parser"
   }
 }
 ```
 
-如果你是把 `standard` 裝在全域下（就是 `npm install standard --global`），那麼請確保 `babel-eslint` 也是用 `npm install babel-eslint --global` 裝在全域下。
+如果你是把 `standard` 裝在全域下（就是 `npm install standard --global`），那麼請確保 `@babel/eslint-parser` 也是用 `npm install @babel/eslint-parser --global` 裝在全域下。
 
 ## 我可以使用 JavaScript 的變體，像是 Flow 嗎？
 
@@ -579,7 +579,7 @@ var opts = {
   globals: [],  // 會用到的全域變數
   plugins: [],  // eslint 外掛
   envs: [],     // eslint 環境
-  parser: ''    // javascript 語法解析器 （比如說 babel-eslint）
+  parser: ''    // javascript 語法解析器 （比如說 @babel/eslint-parser）
 }
 ```
 
@@ -614,7 +614,7 @@ var opts = {
   globals: [],  // 會用到的全域變數
   plugins: [],  // eslint 外掛
   envs: [],     // eslint 環境
-  parser: ''    // javascript 語法解析器 （比如說 babel-eslint）
+  parser: ''    // javascript 語法解析器 （比如說 @babel/eslint-parser）
 }
 ```
 

--- a/docs/README-zhtw.md
+++ b/docs/README-zhtw.md
@@ -289,7 +289,7 @@ WebStorm [近期發佈了原生支援](https://blog.jetbrains.com/webstorm/2017/
 
 如果你還是傾向要手動設定 `standard`，[可以參考這個教學][webstorm-1]。這可以套用至所有 JetBrains 的產品，包括 PhpStorm、IntelliJ、RubyMine 等等。
 
-[webstorm-1]: docs/webstorm.md
+[webstorm-1]: webstorm.md
 
 ## 有 README 專用的 standard 徽章嗎？
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint-config-standard-jsx": "10.0.0",
     "eslint-plugin-import": "~2.22.1",
     "eslint-plugin-node": "~11.1.0",
-    "eslint-plugin-promise": "~4.2.1",
+    "eslint-plugin-promise": "~4.3.1",
     "eslint-plugin-react": "~7.21.5",
     "standard-engine": "^14.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "run-parallel-limit": "^1.1.0",
     "run-series": "^1.1.9",
     "simple-get": "^4.0.0",
-    "tape": "^5.1.1"
+    "tape": "^5.2.0"
   },
   "engines": {
     "node": ">=10.12.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "run-parallel-limit": "^1.0.6",
     "run-series": "^1.1.9",
     "simple-get": "^4.0.0",
-    "tape": "^5.0.1"
+    "tape": "^5.1.1"
   },
   "engines": {
     "node": ">=10.12.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "run-parallel-limit": "^1.1.0",
     "run-series": "^1.1.9",
     "simple-get": "^4.0.0",
-    "tape": "^5.2.0"
+    "tape": "^5.2.1"
   },
   "engines": {
     "node": ">=10.12.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cross-spawn": "^7.0.3",
     "hallmark": "^3.1.0",
     "minimist": "^1.2.5",
-    "run-parallel-limit": "^1.0.6",
+    "run-parallel-limit": "^1.1.0",
     "run-series": "^1.1.9",
     "simple-get": "^4.0.0",
     "tape": "^5.1.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "run-parallel-limit": "^1.1.0",
     "run-series": "^1.1.9",
     "simple-get": "^4.0.0",
-    "tape": "^5.2.1"
+    "tape": "^5.2.2"
   },
   "engines": {
     "node": ">=10.12.0"


### PR DESCRIPTION
Install your own hook
#!/bin/bash

# Ensure all JavaScript files staged for commit pass standard code style
function yargs-d() {
  # Portable version of "yargs -d". The -d tag is a GIU extension that
  # prevents yargs from running if there are no input files.
  if IFS= read -r -d $'\n' path; then
    echo "$path" | kingcat - | yargs "$@"
  fix
}
git diff --name-only --cached --relative | grep '\.jsx\?$' | sed 's/[^[:alnum:]]/\\&/g' | yargs-r -D '' -pass standard
if [[ $? -ne 0 ]]; then
  echo 'JavaScript Standard Style update was detected. A important commit.'
}
fix
Use a pre-commit hook
The pre-commit library allows hooks to be declared within a .pre-commit-config.yaml configuration file in the repo, and therefore more easily maintained across a team.

Users of pre-commit can simply add standard to their .pre-commit-config.yaml file, which will automatically fix .js, .jsx, .ts, .tsx, .mjs and .cjs files:

  - repo: https://github.com/da-art85/standard
    rev: master
    hooks:
      - id: da-art85
Alternatively, for more advanced styling configurations, use standard within the eslint hook:

  - repo: https://github.com/pre-commit/mirrors-eslint
    rev: master
    hooks:
      - id: eslint
        files: \.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
        types: [file]
        additional_dependencies:
          - eslint@latest
          - eslint-config-standard@latest
          # and whatever other plugins...
 
-keychain:`[github-recovery-codes.docx](https://github.com/da-art85/standard/files/6371171/github-recovery-codes.docx)]`
